### PR TITLE
fix: 修复微博 livephoto 下载视频携带 ?query 的问题

### DIFF
--- a/packages/48tools/src/pages/Weibo/ImagesDownload/download.worker/download.worker.ts
+++ b/packages/48tools/src/pages/Weibo/ImagesDownload/download.worker/download.worker.ts
@@ -44,8 +44,15 @@ addEventListener('message', async function(event: MessageEvent<WorkerEventData>)
 
     // 额外下载视频
     if (item.infos.video) {
+      // videoFileUrl: xxx.mov?Expires=xxxx
       const videoFileUrl: string = item.infos.video;
-      const videoFilename: string = path.join(filePath, `${ item.pid }${ path.extname(videoFileUrl) }`);
+      let ext: string = path.extname(videoFileUrl);
+      const queryIndex: number = ext.indexOf('?');
+
+      if (queryIndex !== -1) {
+        ext = ext.substring(0, queryIndex);
+      }
+      const videoFilename: string = path.join(filePath, `${ item.pid }${ ext }`);
 
       downloadList.push(requestDownloadFileByStream(videoFileUrl, videoFilename));
     }


### PR DESCRIPTION
微博视频 url 后面带有 query，会导致下载到本地的时候文件变成
`/path/004rjkzsjx08pyiQKeeA0h041100334b0k01.mov?Expires=1752220888`
<img width="1474" height="366" alt="image" src="https://github.com/user-attachments/assets/cd52094f-6376-48c3-9f6e-d30e460a8989" />
