### PR TITLE
fix: 修复口袋48录播因主播切换 App 导致的音画不同步

### DIFF
--- a/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48Record.tsx
+++ b/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48Record.tsx
@@ -333,6 +333,7 @@ function Pocket48Record(props: {}): ReactElement {
         filePath: result.filePath,
         ffmpeg: getFFmpeg(),
         protocolWhitelist: isM3u8,
+        preserveInputTimestamps: isM3u8,
         qid: record.liveId
       });
 

--- a/packages/48tools/src/utils/worker/FFmpegDownload.worker/FFmpegDownload.worker.ts
+++ b/packages/48tools/src/utils/worker/FFmpegDownload.worker/FFmpegDownload.worker.ts
@@ -18,6 +18,7 @@ export type WorkerEventData = {
   qid?: string;                           // id
   ffmpegHeaders?: string;                 // ffmpeg的headers
   concat?: boolean;                       // 合并
+  preserveInputTimestamps?: boolean;      // 保留输入流原始时间线
   // 是否添加"-flvflags no_duration_filesize"
   // see: https://stackoverflow.com/questions/50300013/ffmpeg-streaming-stops-after-few-seconds
   noDurationFilesize?: boolean;
@@ -112,6 +113,7 @@ function download(workerData: WorkerEventData): void {
     qid,
     ffmpegHeaders,
     concat,
+    preserveInputTimestamps,
     noDurationFilesize
   }: WorkerEventData = workerData;
   let ffmpegArgs: Array<string> = playStreamPathArray(playStreamPath).concat(
@@ -119,6 +121,12 @@ function download(workerData: WorkerEventData): void {
 
   if (libx264) {
     ffmpegArgs = playStreamPathArray(playStreamPath).concat(['-vcodec', 'libx264', filePath]);
+  }
+
+  if (preserveInputTimestamps) {
+    // 口袋48的HLS分片可能暂时没有音频包。复制源时间戳可保留这段静音时间，
+    // start_at_zero只整体平移起点，不改变音视频之间的相对时间。
+    ffmpegArgs.unshift('-copyts', '-start_at_zero');
   }
 
   if (ffmpegHeaders) {


### PR DESCRIPTION
问题说明
口袋48 HLS 录播过程中，如果主播切换 App，如接听电话等，视频流可能继续产生分片，但音频流会暂时中断。
原有下载流程在处理这类时间轴时，会压缩连续无音频分片形成的时间洞，导致音频恢复后相对视频提前，最终出现音画不同步。

修复内容
为口袋48 m3u8 下载任务保留输入流的原始 PTS/DTS。
使用 -copyts 保留源时间轴，并使用 -start_at_zero 将音视频时间轴整体平移至零点，从而保持音视频之间原有的相对时间关系，避免连续无音频区间被压缩。
本次修改针对口袋48的普通 m3u8 视频下载流程，不涉及备用下载方案。