### PR TITLE
fix: 修复口袋48录播切换应用后的音画不同步

### DIFF
--- a/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/Pocket48M3u8Download.worker.ts
+++ b/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/Pocket48M3u8Download.worker.ts
@@ -1,0 +1,547 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import * as fs from 'node:fs';
+import { promises as fsP, type Stats } from 'node:fs';
+import * as path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+// @ts-expect-error
+import got from 'got';
+import type GotRequest from 'got/dist/source/core';
+import {
+  createGroupConcatFile,
+  isSourceBoundary,
+  parseMediaPlaylist,
+  type HlsSegment,
+  type SegmentTimeline,
+  type StreamTimeline
+} from './timeline';
+
+export type WorkerEventData = {
+  ffmpeg: string;
+  type: 'start' | 'stop';
+  playStreamPath: string;
+  filePath: string;
+  qid?: string;
+};
+
+type ProbePacket = {
+  stream_index: number;
+  pts_time?: string;
+  dts_time?: string;
+  duration_time?: string;
+  flags?: string;
+};
+
+type ProbeStream = {
+  index: number;
+  codec_type?: string;
+  codec_name?: string;
+  profile?: string;
+  codec_tag_string?: string;
+  width?: number;
+  height?: number;
+  pix_fmt?: string;
+  level?: number;
+  sample_fmt?: string;
+  sample_rate?: string;
+  channels?: number;
+  channel_layout?: string;
+  extradata?: string;
+};
+
+type ProbeResult = {
+  packets?: ProbePacket[];
+  streams?: ProbeStream[];
+};
+
+type ProbeFormatResult = {
+  format?: {
+    duration?: string;
+  };
+};
+
+type DownloadPartsResult = {
+  partFiles: string[];
+  needsContinuousAudio: boolean;
+};
+
+let activeChild: ChildProcessWithoutNullStreams | null = null;
+let activeRequest: GotRequest | null = null;
+let activeTask: Promise<void> | null = null;
+let isStopped: boolean = false;
+
+function postProgress(qid: string | undefined, value: number): void {
+  if (!qid) return;
+
+  postMessage({
+    type: 'progress',
+    data: Math.min(100, Math.max(0, Number(value.toFixed(2)))),
+    qid
+  });
+}
+
+function getFFprobe(ffmpeg: string): string {
+  const parsed: path.ParsedPath = path.parse(ffmpeg);
+  const extension: string = parsed.ext.toLowerCase() === '.exe' ? '.exe' : '';
+
+  if (/^ffmpeg(?:\.exe)?$/i.test(parsed.base)) {
+    return path.join(parsed.dir, `ffprobe${ extension }`);
+  }
+
+  const replaced: string = ffmpeg.replace(/ffmpeg(?=\.exe$|$)/i, 'ffprobe');
+
+  return replaced === ffmpeg ? path.join(parsed.dir, `ffprobe${ extension }`) : replaced;
+}
+
+function runProcessInternal(command: string, args: string[], captureStdout: boolean): Promise<string> {
+  return new Promise((resolve: (value: string) => void, reject: (reason?: Error) => void): void => {
+    const processChild: ChildProcessWithoutNullStreams = spawn(command, args);
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let settled: boolean = false;
+
+    function rejectOnce(err: Error): void {
+      if (settled) return;
+
+      settled = true;
+      reject(err);
+    }
+
+    activeChild = processChild;
+    processChild.stdout.on('data', function(data: Buffer): void {
+      if (captureStdout) stdout.push(data);
+    });
+    processChild.stderr.on('data', function(data: Buffer): void {
+      stderr.push(data);
+    });
+    processChild.on('error', function(err: Error): void {
+      if (activeChild === processChild) activeChild = null;
+      rejectOnce(err);
+    });
+    processChild.on('close', function(code: number | null): void {
+      if (activeChild === processChild) activeChild = null;
+      if (settled) return;
+
+      settled = true;
+      if (code === 0) {
+        resolve(captureStdout ? Buffer.concat(stdout).toString('utf8') : '');
+      } else {
+        const message: string = Buffer.concat(stderr).toString('utf8').trim();
+
+        reject(new Error(message || `${ path.basename(command) }退出码：${ code ?? 'unknown' }`));
+      }
+    });
+  });
+}
+
+function runProcess(command: string, args: string[]): Promise<void> {
+  return runProcessInternal(command, args, false).then((): undefined => undefined);
+}
+
+function runProcessOutput(command: string, args: string[]): Promise<string> {
+  return runProcessInternal(command, args, true);
+}
+
+function parseNumber(value: string | undefined): number | null {
+  if (value === undefined) return null;
+
+  const result: number = Number(value);
+
+  return Number.isFinite(result) ? result : null;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+
+  const sorted: number[] = [...values].sort((a: number, b: number): number => a - b);
+  const middle: number = Math.floor(sorted.length / 2);
+
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+function createStreamTimeline(stream: ProbeStream, packets: ProbePacket[]): StreamTimeline | null {
+  if (packets.length === 0) return null;
+
+  const ptsValues: number[] = packets
+    .map((packet: ProbePacket): number | null => parseNumber(packet.pts_time))
+    .filter((value: number | null): value is number => value !== null);
+  const dtsValues: number[] = packets
+    .map((packet: ProbePacket): number | null => parseNumber(packet.dts_time))
+    .filter((value: number | null): value is number => value !== null);
+  const orderingValues: number[] = dtsValues.length > 1 ? dtsValues : ptsValues;
+  const steps: number[] = [];
+
+  for (let index: number = 1; index < orderingValues.length; index++) {
+    const step: number = orderingValues[index] - orderingValues[index - 1];
+
+    if (step > 0) steps.push(step);
+  }
+
+  const packetStep: number | null = median(steps);
+  const packetStarts: number[] = [];
+  const packetEnds: number[] = [];
+
+  for (const packet of packets) {
+    const pts: number | null = parseNumber(packet.pts_time);
+    const dts: number | null = parseNumber(packet.dts_time);
+    const packetStart: number | null = pts ?? dts;
+
+    if (packetStart === null) continue;
+
+    packetStarts.push(packetStart);
+    packetEnds.push(packetStart + (parseNumber(packet.duration_time) ?? packetStep ?? 0));
+  }
+
+  return {
+    firstPts: ptsValues[0] ?? null,
+    lastPts: ptsValues.at(-1) ?? null,
+    firstDts: dtsValues[0] ?? null,
+    lastDts: dtsValues.at(-1) ?? null,
+    lastDuration: parseNumber(packets.at(-1)?.duration_time),
+    packetStep,
+    startTime: packetStarts.length > 0 ? Math.min(...packetStarts) : null,
+    endTime: packetEnds.length > 0 ? Math.max(...packetEnds) : null,
+    firstPacketIsKey: packets[0].flags?.includes('K') ?? false,
+    codecSignature: JSON.stringify({
+      codecName: stream.codec_name ?? '',
+      profile: stream.profile ?? '',
+      codecTag: stream.codec_tag_string ?? '',
+      width: stream.width ?? null,
+      height: stream.height ?? null,
+      pixelFormat: stream.pix_fmt ?? '',
+      level: stream.level ?? null,
+      sampleFormat: stream.sample_fmt ?? '',
+      sampleRate: stream.sample_rate ?? '',
+      channels: stream.channels ?? null,
+      channelLayout: stream.channel_layout ?? ''
+    }),
+    codecExtraData: stream.extradata?.replace(/\s/g, '') ?? ''
+  };
+}
+
+async function probeTimeline(ffprobe: string, file: string): Promise<SegmentTimeline> {
+  const output: string = await runProcessOutput(ffprobe, [
+    '-v', 'error',
+    '-show_packets',
+    '-show_streams',
+    '-show_data',
+    '-show_entries',
+    'packet=stream_index,pts_time,dts_time,duration_time,flags:'
+      + 'stream=index,codec_type,codec_name,profile,codec_tag_string,width,height,pix_fmt,level,'
+      + 'sample_fmt,sample_rate,channels,channel_layout,extradata',
+    '-of', 'json',
+    file
+  ]);
+  const result: ProbeResult = JSON.parse(output) as ProbeResult;
+  const streams: ProbeStream[] = result.streams ?? [];
+  const packets: ProbePacket[] = result.packets ?? [];
+  const videoStream: ProbeStream | undefined = streams.find(
+    (stream: ProbeStream): boolean => stream.codec_type === 'video'
+  );
+  const audioStream: ProbeStream | undefined = streams.find(
+    (stream: ProbeStream): boolean => stream.codec_type === 'audio'
+  );
+  const timeline: SegmentTimeline = {
+    video: videoStream
+      ? createStreamTimeline(videoStream, packets.filter(
+        (packet: ProbePacket): boolean => packet.stream_index === videoStream.index
+      ))
+      : null,
+    audio: audioStream
+      ? createStreamTimeline(audioStream, packets.filter(
+        (packet: ProbePacket): boolean => packet.stream_index === audioStream.index
+      ))
+      : null
+  };
+
+  if (!timeline.video && !timeline.audio) {
+    throw new Error(`媒体分片中没有可识别的音视频流：${ path.basename(file) }`);
+  }
+
+  return timeline;
+}
+
+async function downloadSegment(uri: string, file: string): Promise<void> {
+  const url: URL = new URL(uri);
+  const request: GotRequest = got.stream(uri, {
+    headers: {
+      'Host': url.hostname,
+      'User-Agent': 'SNH48 ENGINE'
+    }
+  });
+
+  activeRequest = request;
+  try {
+    await pipeline(request, fs.createWriteStream(file));
+  } finally {
+    activeRequest = null;
+  }
+
+  const fileStat: Stats = await fsP.stat(file);
+
+  if (fileStat.size === 0) {
+    throw new Error(`TS分片下载为空：${ uri }`);
+  }
+}
+
+async function appendSegment(segmentFile: string, partFile: string, truncate: boolean): Promise<void> {
+  await pipeline(
+    fs.createReadStream(segmentFile),
+    fs.createWriteStream(partFile, { flags: truncate ? 'w' : 'a' })
+  );
+}
+
+function getPartFile(filePath: string, partIndex: number): string {
+  if (partIndex === 0) return filePath;
+
+  const parsed: path.ParsedPath = path.parse(filePath);
+  const suffix: string = String(partIndex + 1).padStart(3, '0');
+
+  return path.join(parsed.dir, `${ parsed.name }_${ suffix }${ parsed.ext }`);
+}
+
+async function downloadParts(
+  ffprobe: string,
+  workDir: string,
+  filePath: string,
+  segments: HlsSegment[],
+  qid?: string
+): Promise<DownloadPartsResult> {
+  const partFiles: string[] = [];
+  const segmentFile: string = path.join(workDir, '_current_segment.ts');
+  let previousTimeline: SegmentTimeline | null = null;
+  let hasAudio: boolean = false;
+  let hasVideoWithoutAudio: boolean = false;
+
+  for (let index: number = 0; index < segments.length; index++) {
+    if (isStopped) break;
+
+    const segment: HlsSegment = segments[index];
+
+    try {
+      await downloadSegment(segment.uri, segmentFile);
+      if (isStopped) break;
+
+      const timeline: SegmentTimeline = await probeTimeline(ffprobe, segmentFile);
+      const startsNewPart: boolean = previousTimeline === null
+        || isSourceBoundary(segment, previousTimeline, timeline);
+
+      hasAudio ||= timeline.audio !== null;
+      hasVideoWithoutAudio ||= timeline.video !== null && timeline.audio === null;
+
+      if (startsNewPart) {
+        partFiles.push(getPartFile(filePath, partFiles.length));
+      }
+
+      await appendSegment(segmentFile, partFiles.at(-1) as string, startsNewPart);
+      previousTimeline = timeline;
+      postProgress(qid, (index + 1) / segments.length * 90);
+    } finally {
+      await fsP.rm(segmentFile, { force: true });
+    }
+  }
+
+  return {
+    partFiles,
+    needsContinuousAudio: hasAudio && hasVideoWithoutAudio
+  };
+}
+
+async function probeDuration(ffprobe: string, file: string): Promise<number> {
+  const output: string = await runProcessOutput(ffprobe, [
+    '-v', 'error',
+    '-show_entries', 'format=duration',
+    '-of', 'json',
+    file
+  ]);
+  const result: ProbeFormatResult = JSON.parse(output) as ProbeFormatResult;
+  const duration: number | null = parseNumber(result.format?.duration);
+
+  if (duration === null || duration <= 0) {
+    throw new Error(`无法获取分段视频时长：${ path.basename(file) }`);
+  }
+
+  return duration;
+}
+
+async function normalizeParts(
+  ffmpeg: string,
+  ffprobe: string,
+  workDir: string,
+  partFiles: string[],
+  qid?: string
+): Promise<Array<{ filename: string; duration: number }>> {
+  const result: Array<{ filename: string; duration: number }> = [];
+
+  for (let index: number = 0; index < partFiles.length; index++) {
+    if (isStopped) return result;
+
+    const outputFilename: string = `_normalized_${ String(index).padStart(4, '0') }.ts`;
+    const outputFile: string = path.join(workDir, outputFilename);
+
+    await runProcess(ffmpeg, [
+      '-y',
+      '-v', 'error',
+      '-copyts',
+      '-start_at_zero',
+      '-i', partFiles[index],
+      '-map', '0:v:0?',
+      '-map', '0:a:0?',
+      '-c', 'copy',
+      '-muxpreload', '0',
+      '-muxdelay', '0',
+      outputFile
+    ]);
+
+    result.push({ filename: outputFilename, duration: await probeDuration(ffprobe, outputFile) });
+    postProgress(qid, 90 + (((index + 1) / partFiles.length) * 8));
+  }
+
+  return result;
+}
+
+async function createVideo(workerData: WorkerEventData, partsDir: string): Promise<void> {
+  const { ffmpeg, playStreamPath, filePath, qid }: WorkerEventData = workerData;
+  const playlistData: string = await fsP.readFile(playStreamPath, { encoding: 'utf8' });
+  const segments: HlsSegment[] = parseMediaPlaylist(playlistData);
+
+  if (segments.length === 0) {
+    throw new Error('m3u8中没有可下载的TS分片。');
+  }
+
+  const ffprobe: string = getFFprobe(ffmpeg);
+  const downloadResult: DownloadPartsResult = await downloadParts(
+    ffprobe,
+    partsDir,
+    filePath,
+    segments,
+    qid
+  );
+  const { partFiles, needsContinuousAudio }: DownloadPartsResult = downloadResult;
+
+  if (isStopped) return;
+  if (partFiles.length === 0) throw new Error('没有已完成的TS分段。');
+
+  if (partFiles.length === 1) {
+    postProgress(qid, 100);
+
+    return;
+  }
+
+  const groupFiles: Array<{ filename: string; duration: number }> = await normalizeParts(
+    ffmpeg,
+    ffprobe,
+    partsDir,
+    partFiles,
+    qid
+  );
+
+  if (isStopped) return;
+
+  const concatFile: string = path.join(partsDir, '_sources.ffconcat');
+  const mergedFile: string = path.join(partsDir, '_merged.ts');
+  const concatOutputFile: string = needsContinuousAudio
+    ? path.join(partsDir, '_merged_sparse_audio.ts')
+    : mergedFile;
+
+  await fsP.writeFile(concatFile, createGroupConcatFile(groupFiles), { encoding: 'utf8' });
+  postProgress(qid, 99);
+  await runProcess(ffmpeg, [
+    '-y',
+    '-v', 'error',
+    '-f', 'concat',
+    '-safe', '0',
+    '-i', concatFile,
+    '-map', '0:v:0?',
+    '-map', '0:a:0?',
+    '-c', 'copy',
+    '-muxpreload', '0',
+    '-muxdelay', '0',
+    concatOutputFile
+  ]);
+
+  if (needsContinuousAudio) {
+    await runProcess(ffmpeg, [
+      '-y',
+      '-v', 'error',
+      '-copyts',
+      '-start_at_zero',
+      '-i', concatOutputFile,
+      '-map', '0:v:0?',
+      '-map', '0:a:0',
+      '-c:v', 'copy',
+      '-af', 'aresample=async=1:first_pts=0,apad',
+      '-c:a', 'aac',
+      '-b:a', '64k',
+      '-shortest',
+      '-muxpreload', '0',
+      '-muxdelay', '0',
+      mergedFile
+    ]);
+  }
+
+  await fsP.rename(mergedFile, filePath);
+
+  for (const partFile of partFiles.slice(1)) {
+    try {
+      await fsP.rm(partFile, { force: true });
+    } catch { /**/ }
+  }
+
+  postProgress(qid, 100);
+}
+
+function normalizeError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+async function run(workerData: WorkerEventData): Promise<void> {
+  let partsDir: string | null = null;
+  let caughtError: Error | null = null;
+
+  isStopped = false;
+  try {
+    partsDir = await fsP.mkdtemp(`${ workerData.filePath }.parts-`);
+    await createVideo(workerData, partsDir);
+  } catch (err) {
+    caughtError = normalizeError(err);
+  }
+
+  if (partsDir) {
+    try {
+      await fsP.rm(partsDir, { force: true, recursive: true });
+    } catch { /**/ }
+  }
+
+  if (isStopped) {
+    postMessage({ type: 'close', qid: workerData.qid });
+  } else if (caughtError) {
+    postMessage({ type: 'error', error: caughtError });
+  } else {
+    postMessage({ type: 'close', qid: workerData.qid });
+  }
+}
+
+function stop(): void {
+  isStopped = true;
+  try {
+    activeRequest?.destroy();
+  } catch { /**/ }
+  activeRequest = null;
+  activeChild?.kill('SIGTERM');
+}
+
+addEventListener('message', function(event: MessageEvent<WorkerEventData>): void {
+  switch (event.data.type) {
+    case 'start':
+      if (!activeTask) {
+        activeTask = run(event.data).finally(function(): void {
+          activeTask = null;
+        });
+      }
+      break;
+
+    case 'stop':
+      stop();
+      break;
+  }
+});

--- a/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/Pocket48M3u8Download.worker.ts
+++ b/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/Pocket48M3u8Download.worker.ts
@@ -7,6 +7,11 @@ import { pipeline } from 'node:stream/promises';
 import got from 'got';
 import type GotRequest from 'got/dist/source/core';
 import {
+  inspectTsSegment,
+  type AudioFormat,
+  type SegmentProbeResult
+} from './inspectTs';
+import {
   createGroupConcatFile,
   isSourceBoundary,
   parseMediaPlaylist,
@@ -61,6 +66,8 @@ type ProbeFormatResult = {
 
 type DownloadPartsResult = {
   partFiles: string[];
+  partHasAudio: boolean[];
+  audioFormat: AudioFormat | null;
   needsContinuousAudio: boolean;
 };
 
@@ -218,7 +225,16 @@ function createStreamTimeline(stream: ProbeStream, packets: ProbePacket[]): Stre
   };
 }
 
-async function probeTimeline(ffprobe: string, file: string): Promise<SegmentTimeline> {
+function getAudioFormat(stream: ProbeStream): AudioFormat {
+  const channels: number = stream.channels ?? 2;
+
+  return {
+    sampleRate: stream.sample_rate ?? '44100',
+    channelLayout: stream.channel_layout ?? (channels === 1 ? 'mono' : channels === 2 ? 'stereo' : `${ channels }c`)
+  };
+}
+
+async function probeSegmentWithFFprobe(ffprobe: string, file: string): Promise<SegmentProbeResult> {
   const output: string = await runProcessOutput(ffprobe, [
     '-v', 'error',
     '-show_packets',
@@ -257,7 +273,18 @@ async function probeTimeline(ffprobe: string, file: string): Promise<SegmentTime
     throw new Error(`媒体分片中没有可识别的音视频流：${ path.basename(file) }`);
   }
 
-  return timeline;
+  return {
+    timeline,
+    audioFormat: audioStream ? getAudioFormat(audioStream) : null
+  };
+}
+
+async function probeSegment(ffprobe: string, file: string): Promise<SegmentProbeResult> {
+  try {
+    return inspectTsSegment(await fsP.readFile(file));
+  } catch {
+    return probeSegmentWithFFprobe(ffprobe, file);
+  }
 }
 
 async function downloadSegment(uri: string, file: string): Promise<void> {
@@ -307,8 +334,10 @@ async function downloadParts(
   qid?: string
 ): Promise<DownloadPartsResult> {
   const partFiles: string[] = [];
+  const partHasAudio: boolean[] = [];
   const segmentFile: string = path.join(workDir, '_current_segment.ts');
   let previousTimeline: SegmentTimeline | null = null;
+  let audioFormat: AudioFormat | null = null;
   let hasAudio: boolean = false;
   let hasVideoWithoutAudio: boolean = false;
 
@@ -321,15 +350,20 @@ async function downloadParts(
       await downloadSegment(segment.uri, segmentFile);
       if (isStopped) break;
 
-      const timeline: SegmentTimeline = await probeTimeline(ffprobe, segmentFile);
+      const probeResult: SegmentProbeResult = await probeSegment(ffprobe, segmentFile);
+      const { timeline }: SegmentProbeResult = probeResult;
       const startsNewPart: boolean = previousTimeline === null
         || isSourceBoundary(segment, previousTimeline, timeline);
 
       hasAudio ||= timeline.audio !== null;
       hasVideoWithoutAudio ||= timeline.video !== null && timeline.audio === null;
+      audioFormat ??= probeResult.audioFormat;
 
       if (startsNewPart) {
         partFiles.push(getPartFile(filePath, partFiles.length));
+        partHasAudio.push(timeline.audio !== null);
+      } else if (timeline.audio) {
+        partHasAudio[partHasAudio.length - 1] = true;
       }
 
       await appendSegment(segmentFile, partFiles.at(-1) as string, startsNewPart);
@@ -342,6 +376,8 @@ async function downloadParts(
 
   return {
     partFiles,
+    partHasAudio,
+    audioFormat,
     needsContinuousAudio: hasAudio && hasVideoWithoutAudio
   };
 }
@@ -368,6 +404,8 @@ async function normalizeParts(
   ffprobe: string,
   workDir: string,
   partFiles: string[],
+  partHasAudio: boolean[],
+  silentAudioFormat: AudioFormat | null,
   qid?: string
 ): Promise<Array<{ filename: string; duration: number }>> {
   const result: Array<{ filename: string; duration: number }> = [];
@@ -378,19 +416,40 @@ async function normalizeParts(
     const outputFilename: string = `_normalized_${ String(index).padStart(4, '0') }.ts`;
     const outputFile: string = path.join(workDir, outputFilename);
 
-    await runProcess(ffmpeg, [
-      '-y',
-      '-v', 'error',
-      '-copyts',
-      '-start_at_zero',
-      '-i', partFiles[index],
-      '-map', '0:v:0?',
-      '-map', '0:a:0?',
-      '-c', 'copy',
-      '-muxpreload', '0',
-      '-muxdelay', '0',
-      outputFile
-    ]);
+    if (silentAudioFormat && !partHasAudio[index]) {
+      await runProcess(ffmpeg, [
+        '-y',
+        '-v', 'error',
+        '-copyts',
+        '-start_at_zero',
+        '-i', partFiles[index],
+        '-f', 'lavfi',
+        '-i', `anullsrc=r=${ silentAudioFormat.sampleRate }:cl=${ silentAudioFormat.channelLayout }`,
+        '-map', '0:v:0',
+        '-map', '1:a:0',
+        '-c:v', 'copy',
+        '-c:a', 'aac',
+        '-b:a', '64k',
+        '-shortest',
+        '-muxpreload', '0',
+        '-muxdelay', '0',
+        outputFile
+      ]);
+    } else {
+      await runProcess(ffmpeg, [
+        '-y',
+        '-v', 'error',
+        '-copyts',
+        '-start_at_zero',
+        '-i', partFiles[index],
+        '-map', '0:v:0?',
+        '-map', '0:a:0?',
+        '-c', 'copy',
+        '-muxpreload', '0',
+        '-muxdelay', '0',
+        outputFile
+      ]);
+    }
 
     result.push({ filename: outputFilename, duration: await probeDuration(ffprobe, outputFile) });
     postProgress(qid, 90 + (((index + 1) / partFiles.length) * 8));
@@ -416,7 +475,12 @@ async function createVideo(workerData: WorkerEventData, partsDir: string): Promi
     segments,
     qid
   );
-  const { partFiles, needsContinuousAudio }: DownloadPartsResult = downloadResult;
+  const {
+    partFiles,
+    partHasAudio,
+    audioFormat,
+    needsContinuousAudio
+  }: DownloadPartsResult = downloadResult;
 
   if (isStopped) return;
   if (partFiles.length === 0) throw new Error('没有已完成的TS分段。');
@@ -427,11 +491,17 @@ async function createVideo(workerData: WorkerEventData, partsDir: string): Promi
     return;
   }
 
+  if (needsContinuousAudio && !audioFormat) {
+    throw new Error('无法获取静音分段所需的音频参数。');
+  }
+
   const groupFiles: Array<{ filename: string; duration: number }> = await normalizeParts(
     ffmpeg,
     ffprobe,
     partsDir,
     partFiles,
+    partHasAudio,
+    needsContinuousAudio ? audioFormat : null,
     qid
   );
 

--- a/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/inspectTs.spec.ts
+++ b/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/inspectTs.spec.ts
@@ -1,0 +1,118 @@
+import { inspectTsSegment, type SegmentProbeResult } from './inspectTs';
+
+function encodePts(value: number): Buffer {
+  const timestamp: number = Math.round(value * 90000);
+
+  return Buffer.from([
+    0x21 | (Math.floor(timestamp / 1073741824) << 1),
+    Math.floor(timestamp / 4194304) & 0xff,
+    ((Math.floor(timestamp / 32768) & 0x7f) << 1) | 1,
+    Math.floor(timestamp / 128) & 0xff,
+    ((timestamp & 0x7f) << 1) | 1
+  ]);
+}
+
+function transportPacket(pid: number, payload: Buffer, startsUnit: boolean = true): Buffer {
+  if (payload.length > 184) throw new Error('测试负载超过单个TS包容量。');
+
+  const result: Buffer = Buffer.alloc(188, 0xff);
+
+  result[0] = 0x47;
+  result[1] = (startsUnit ? 0x40 : 0) | ((pid >> 8) & 0x1f);
+  result[2] = pid & 0xff;
+  result[3] = 0x10;
+  payload.copy(result, 4);
+
+  return result;
+}
+
+function psiPacket(pid: number, section: number[]): Buffer {
+  return transportPacket(pid, Buffer.from([0, ...section]));
+}
+
+function pesPacket(pid: number, streamId: number, pts: number, data: Buffer): Buffer {
+  return transportPacket(pid, Buffer.concat([
+    Buffer.from([0, 0, 1, streamId, 0, 0, 0x80, 0x80, 5]),
+    encodePts(pts),
+    data
+  ]));
+}
+
+function pat(): Buffer {
+  return psiPacket(0, [
+    0x00, 0xb0, 0x0d, 0x00, 0x01, 0xc1, 0x00, 0x00,
+    0x00, 0x01, 0xf0, 0x00, 0, 0, 0, 0
+  ]);
+}
+
+function pmt(withAudio: boolean): Buffer {
+  const streams: number[] = [0x1b, 0xe1, 0x00, 0xf0, 0x00];
+
+  if (withAudio) streams.push(0x0f, 0xe1, 0x01, 0xf0, 0x00);
+
+  const sectionLength: number = 9 + streams.length + 4;
+
+  return psiPacket(0x1000, [
+    0x02, 0xb0 | ((sectionLength >> 8) & 0x0f), sectionLength & 0xff,
+    0x00, 0x01, 0xc1, 0x00, 0x00, 0xe1, 0x00, 0xf0, 0x00,
+    ...streams,
+    0, 0, 0, 0
+  ]);
+}
+
+function videoData(key: boolean): Buffer {
+  return Buffer.from([
+    0, 0, 0, 1, 0x67, 0x64, 0x00, 0x1f,
+    0, 0, 0, 1, 0x68, 0xee, 0x3c, 0x80,
+    0, 0, 0, 1, key ? 0x65 : 0x41, 0x88, 0x84
+  ]);
+}
+
+function adtsFrame(): Buffer {
+  const frameLength: number = 9;
+
+  return Buffer.from([
+    0xff, 0xf1, 0x50, 0x80 | (frameLength >> 11),
+    (frameLength >> 3) & 0xff,
+    ((frameLength & 0x07) << 5) | 0x1f,
+    0xfc,
+    0, 0
+  ]);
+}
+
+function createSegment(withAudio: boolean): Buffer {
+  const packets: Buffer[] = [
+    pat(),
+    pmt(withAudio),
+    pesPacket(0x100, 0xe0, 0, videoData(true)),
+    pesPacket(0x100, 0xe0, 0.05, videoData(false))
+  ];
+
+  if (withAudio) {
+    packets.push(
+      pesPacket(0x101, 0xc0, 0, adtsFrame()),
+      pesPacket(0x101, 0xc0, 1024 / 44100, adtsFrame())
+    );
+  }
+
+  return Buffer.concat(packets);
+}
+
+describe('Pocket48 MPEG-TS inspector', function(): void {
+  test('extracts video and AAC timelines without ffprobe', function(): void {
+    const result: SegmentProbeResult = inspectTsSegment(createSegment(true));
+
+    expect(result.timeline.video?.firstPacketIsKey).toBe(true);
+    expect(result.timeline.video?.packetStep).toBeCloseTo(0.05, 6);
+    expect(result.timeline.audio?.packetStep).toBeCloseTo(2090 / 90000, 6);
+    expect(result.audioFormat).toEqual({ sampleRate: '44100', channelLayout: 'stereo' });
+  });
+
+  test('reports a video-only source without inventing an audio timeline', function(): void {
+    const result: SegmentProbeResult = inspectTsSegment(createSegment(false));
+
+    expect(result.timeline.video).not.toBeNull();
+    expect(result.timeline.audio).toBeNull();
+    expect(result.audioFormat).toBeNull();
+  });
+});

--- a/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/inspectTs.ts
+++ b/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/inspectTs.ts
@@ -1,0 +1,499 @@
+import type { SegmentTimeline, StreamTimeline } from './timeline';
+
+export type AudioFormat = {
+  sampleRate: string;
+  channelLayout: string;
+};
+
+export type SegmentProbeResult = {
+  timeline: SegmentTimeline;
+  audioFormat: AudioFormat | null;
+};
+
+type StreamDefinition = {
+  pid: number;
+  kind: 'video' | 'audio';
+  codec: 'h264' | 'hevc' | 'aac';
+};
+
+type TransportPayload = {
+  pid: number;
+  startsUnit: boolean;
+  data: Buffer;
+};
+
+type PendingPes = {
+  pts: number | null;
+  dts: number | null;
+  chunks: Buffer[];
+};
+
+type PesPacket = {
+  pts: number | null;
+  dts: number | null;
+  data: Buffer;
+};
+
+type MediaPacket = {
+  pts: number | null;
+  dts: number | null;
+  duration: number | null;
+  key: boolean;
+};
+
+type AudioInspection = {
+  packets: MediaPacket[];
+  format: AudioFormat | null;
+  codecSignature: string;
+  codecExtraData: string;
+};
+
+const TS_PACKET_SIZE: number = 188;
+const CLOCK_RATE: number = 90000;
+const AAC_SAMPLE_RATES: number[] = [
+  96000, 88200, 64000, 48000, 44100, 32000, 24000,
+  22050, 16000, 12000, 11025, 8000, 7350
+];
+const UNSUPPORTED_MEDIA_TYPES: Set<number> = new Set([
+  0x01, 0x02, 0x03, 0x04, 0x10, 0x11, 0x1f, 0x20,
+  0x21, 0x42, 0x81, 0x87, 0xea
+]);
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+
+  const sorted: number[] = [...values].sort((a: number, b: number): number => a - b);
+  const middle: number = Math.floor(sorted.length / 2);
+
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+function findPacketOffset(data: Buffer): number {
+  const searchLength: number = Math.min(TS_PACKET_SIZE, data.length);
+
+  for (let offset: number = 0; offset < searchLength; offset++) {
+    if (data[offset] !== 0x47) continue;
+    if (offset + TS_PACKET_SIZE >= data.length || data[offset + TS_PACKET_SIZE] === 0x47) return offset;
+  }
+
+  throw new Error('TS分片中没有找到同步字节。');
+}
+
+function getTransportPayload(data: Buffer, offset: number): TransportPayload | null {
+  if (data[offset] !== 0x47 || offset + TS_PACKET_SIZE > data.length) return null;
+  if ((data[offset + 1] & 0x80) !== 0) return null;
+
+  const pid: number = ((data[offset + 1] & 0x1f) << 8) | data[offset + 2];
+  const startsUnit: boolean = (data[offset + 1] & 0x40) !== 0;
+  const adaptationControl: number = (data[offset + 3] >> 4) & 0x03;
+
+  if (adaptationControl === 0 || adaptationControl === 2) return null;
+
+  let payloadOffset: number = offset + 4;
+
+  if (adaptationControl === 3) {
+    payloadOffset += 1 + data[payloadOffset];
+  }
+
+  const packetEnd: number = offset + TS_PACKET_SIZE;
+
+  if (payloadOffset >= packetEnd) return null;
+
+  return {
+    pid,
+    startsUnit,
+    data: data.subarray(payloadOffset, packetEnd)
+  };
+}
+
+function getPsiSection(payload: Buffer): Buffer | null {
+  if (payload.length < 4) return null;
+
+  const sectionStart: number = 1 + payload[0];
+
+  if (sectionStart + 3 > payload.length) return null;
+
+  const sectionLength: number = ((payload[sectionStart + 1] & 0x0f) << 8) | payload[sectionStart + 2];
+  const sectionEnd: number = sectionStart + 3 + sectionLength;
+
+  return sectionEnd <= payload.length ? payload.subarray(sectionStart, sectionEnd) : null;
+}
+
+function parsePat(payload: Buffer): number | null {
+  const section: Buffer | null = getPsiSection(payload);
+
+  if (!section || section[0] !== 0x00 || section.length < 12) return null;
+
+  const entriesEnd: number = section.length - 4;
+
+  for (let offset: number = 8; offset + 4 <= entriesEnd; offset += 4) {
+    const programNumber: number = (section[offset] << 8) | section[offset + 1];
+
+    if (programNumber !== 0) {
+      return ((section[offset + 2] & 0x1f) << 8) | section[offset + 3];
+    }
+  }
+
+  return null;
+}
+
+function getStreamDefinition(streamType: number, pid: number): StreamDefinition | null {
+  switch (streamType) {
+    case 0x1b:
+      return { pid, kind: 'video', codec: 'h264' };
+
+    case 0x24:
+      return { pid, kind: 'video', codec: 'hevc' };
+
+    case 0x0f:
+      return { pid, kind: 'audio', codec: 'aac' };
+
+    default:
+      return null;
+  }
+}
+
+function parsePmt(payload: Buffer): StreamDefinition[] {
+  const section: Buffer | null = getPsiSection(payload);
+
+  if (!section || section[0] !== 0x02 || section.length < 16) return [];
+
+  const programInfoLength: number = ((section[10] & 0x0f) << 8) | section[11];
+  const streamsEnd: number = section.length - 4;
+  const result: StreamDefinition[] = [];
+  let offset: number = 12 + programInfoLength;
+
+  while (offset + 5 <= streamsEnd) {
+    const streamType: number = section[offset];
+    const pid: number = ((section[offset + 1] & 0x1f) << 8) | section[offset + 2];
+    const infoLength: number = ((section[offset + 3] & 0x0f) << 8) | section[offset + 4];
+    const definition: StreamDefinition | null = getStreamDefinition(streamType, pid);
+
+    if (definition) result.push(definition);
+    else if (UNSUPPORTED_MEDIA_TYPES.has(streamType)) {
+      throw new Error(`暂不支持进程内解析TS流类型：0x${ streamType.toString(16) }`);
+    }
+
+    offset += 5 + infoLength;
+  }
+
+  return result;
+}
+
+function discoverStreams(data: Buffer, packetOffset: number): StreamDefinition[] {
+  let pmtPid: number | null = null;
+  const streams: Map<number, StreamDefinition> = new Map();
+
+  for (let offset: number = packetOffset; offset + TS_PACKET_SIZE <= data.length; offset += TS_PACKET_SIZE) {
+    const payload: TransportPayload | null = getTransportPayload(data, offset);
+
+    if (!payload?.startsUnit) continue;
+
+    if (payload.pid === 0) {
+      pmtPid = parsePat(payload.data) ?? pmtPid;
+    } else if (pmtPid !== null && payload.pid === pmtPid) {
+      for (const stream of parsePmt(payload.data)) streams.set(stream.pid, stream);
+    }
+  }
+
+  if (streams.size === 0) throw new Error('TS分片中没有找到支持的音视频节目。');
+
+  return [...streams.values()];
+}
+
+function decodeTimestamp(data: Buffer, offset: number): number | null {
+  if (offset + 5 > data.length) return null;
+
+  const value: number = (((data[offset] >> 1) & 0x07) * 1073741824)
+    + (data[offset + 1] * 4194304)
+    + (((data[offset + 2] >> 1) & 0x7f) * 32768)
+    + (data[offset + 3] * 128)
+    + ((data[offset + 4] >> 1) & 0x7f);
+
+  return value / CLOCK_RATE;
+}
+
+function parsePesStart(payload: Buffer): PendingPes | null {
+  if (payload.length < 9 || payload[0] !== 0 || payload[1] !== 0 || payload[2] !== 1) return null;
+
+  const flags: number = payload[7];
+  const headerLength: number = payload[8];
+  const dataOffset: number = 9 + headerLength;
+
+  if (dataOffset > payload.length) return null;
+
+  return {
+    pts: (flags & 0x80) !== 0 ? decodeTimestamp(payload, 9) : null,
+    dts: (flags & 0x40) !== 0 ? decodeTimestamp(payload, 14) : null,
+    chunks: [payload.subarray(dataOffset)]
+  };
+}
+
+function finishPes(target: PesPacket[], pending: PendingPes | undefined): void {
+  if (!pending) return;
+
+  target.push({
+    pts: pending.pts,
+    dts: pending.dts ?? pending.pts,
+    data: Buffer.concat(pending.chunks)
+  });
+}
+
+function collectPesPackets(
+  data: Buffer,
+  packetOffset: number,
+  streams: StreamDefinition[]
+): Map<number, PesPacket[]> {
+  const streamPids: Set<number> = new Set(streams.map((stream: StreamDefinition): number => stream.pid));
+  const pending: Map<number, PendingPes> = new Map();
+  const result: Map<number, PesPacket[]> = new Map(
+    streams.map((stream: StreamDefinition): [number, PesPacket[]] => [stream.pid, []])
+  );
+
+  for (let offset: number = packetOffset; offset + TS_PACKET_SIZE <= data.length; offset += TS_PACKET_SIZE) {
+    const payload: TransportPayload | null = getTransportPayload(data, offset);
+
+    if (!payload || !streamPids.has(payload.pid)) continue;
+
+    if (payload.startsUnit) {
+      finishPes(result.get(payload.pid) as PesPacket[], pending.get(payload.pid));
+
+      const next: PendingPes | null = parsePesStart(payload.data);
+
+      if (next) pending.set(payload.pid, next);
+      else pending.delete(payload.pid);
+    } else {
+      pending.get(payload.pid)?.chunks.push(payload.data);
+    }
+  }
+
+  for (const stream of streams) {
+    finishPes(result.get(stream.pid) as PesPacket[], pending.get(stream.pid));
+  }
+
+  return result;
+}
+
+function findNalStart(data: Buffer, from: number): { offset: number; length: number } | null {
+  for (let offset: number = from; offset + 3 < data.length; offset++) {
+    if (data[offset] !== 0 || data[offset + 1] !== 0) continue;
+
+    if (data[offset + 2] === 1) return { offset, length: 3 };
+    if (data[offset + 2] === 0 && data[offset + 3] === 1) return { offset, length: 4 };
+  }
+
+  return null;
+}
+
+function inspectVideoPes(
+  pesPackets: PesPacket[],
+  codec: 'h264' | 'hevc'
+): { packets: MediaPacket[]; codecExtraData: string } {
+  const mediaPackets: MediaPacket[] = [];
+  const parameterSets: Set<string> = new Set();
+
+  for (const pes of pesPackets) {
+    let key: boolean = false;
+    let current: { offset: number; length: number } | null = findNalStart(pes.data, 0);
+
+    while (current) {
+      const nalOffset: number = current.offset + current.length;
+      const next: { offset: number; length: number } | null = findNalStart(pes.data, nalOffset);
+      const nalEnd: number = next?.offset ?? pes.data.length;
+
+      if (nalOffset < nalEnd) {
+        const nalType: number = codec === 'h264'
+          ? pes.data[nalOffset] & 0x1f
+          : (pes.data[nalOffset] >> 1) & 0x3f;
+        const isKey: boolean = codec === 'h264' ? nalType === 5 : nalType >= 16 && nalType <= 21;
+        const isParameterSet: boolean = codec === 'h264'
+          ? nalType === 7 || nalType === 8
+          : nalType === 32 || nalType === 33 || nalType === 34;
+
+        key ||= isKey;
+        if (isParameterSet) parameterSets.add(pes.data.subarray(nalOffset, nalEnd).toString('hex'));
+      }
+
+      current = next;
+    }
+
+    if (pes.pts !== null || pes.dts !== null) {
+      mediaPackets.push({ pts: pes.pts, dts: pes.dts, duration: null, key });
+    }
+  }
+
+  return {
+    packets: mediaPackets,
+    codecExtraData: [...parameterSets].join('|')
+  };
+}
+
+function getChannelLayout(channelConfig: number): string {
+  switch (channelConfig) {
+    case 1: return 'mono';
+    case 2: return 'stereo';
+    case 3: return '2.1';
+    case 4: return '4.0';
+    case 5: return '5.0';
+    case 6: return '5.1';
+    case 7: return '7.1';
+    default: return `${ Math.max(1, channelConfig) }c`;
+  }
+}
+
+function inspectAudioPes(pesPackets: PesPacket[]): AudioInspection {
+  const packets: MediaPacket[] = [];
+  const configurations: Set<string> = new Set();
+  let format: AudioFormat | null = null;
+
+  for (const pes of pesPackets) {
+    let offset: number = 0;
+    let frameIndex: number = 0;
+
+    while (offset + 7 <= pes.data.length) {
+      if (pes.data[offset] !== 0xff || (pes.data[offset + 1] & 0xf6) !== 0xf0) {
+        offset++;
+        continue;
+      }
+
+      const sampleRateIndex: number = (pes.data[offset + 2] >> 2) & 0x0f;
+      const sampleRate: number | undefined = AAC_SAMPLE_RATES[sampleRateIndex];
+      const channelConfig: number = ((pes.data[offset + 2] & 0x01) << 2)
+        | ((pes.data[offset + 3] >> 6) & 0x03);
+      const frameLength: number = ((pes.data[offset + 3] & 0x03) << 11)
+        | (pes.data[offset + 4] << 3)
+        | ((pes.data[offset + 5] >> 5) & 0x07);
+
+      if (!sampleRate || frameLength < 7 || offset + frameLength > pes.data.length) {
+        offset++;
+        continue;
+      }
+
+      const audioObjectType: number = ((pes.data[offset + 2] >> 6) & 0x03) + 1;
+      const rawBlocks: number = pes.data[offset + 6] & 0x03;
+      const duration: number = 1024 * (rawBlocks + 1) / sampleRate;
+      const pts: number | null = pes.pts === null ? null : pes.pts + (frameIndex * duration);
+      const channelLayout: string = getChannelLayout(channelConfig);
+      const extraData: string = Buffer.from([
+        (audioObjectType << 3) | (sampleRateIndex >> 1),
+        ((sampleRateIndex & 1) << 7) | (channelConfig << 3)
+      ]).toString('hex');
+
+      format ??= { sampleRate: String(sampleRate), channelLayout };
+      configurations.add(`${ audioObjectType }:${ sampleRate }:${ channelLayout }:${ extraData }`);
+
+      if (pts !== null) packets.push({ pts, dts: pts, duration, key: true });
+
+      frameIndex++;
+      offset += frameLength;
+    }
+  }
+
+  return {
+    packets,
+    format,
+    codecSignature: `aac:${ [...configurations].join('|') }`,
+    codecExtraData: [...configurations].join('|')
+  };
+}
+
+function createTimeline(
+  packets: MediaPacket[],
+  codecSignature: string,
+  codecExtraData: string
+): StreamTimeline | null {
+  if (packets.length === 0) return null;
+
+  const ptsValues: number[] = packets
+    .map((packet: MediaPacket): number | null => packet.pts)
+    .filter((value: number | null): value is number => value !== null);
+  const dtsValues: number[] = packets
+    .map((packet: MediaPacket): number | null => packet.dts)
+    .filter((value: number | null): value is number => value !== null);
+  const orderingValues: number[] = dtsValues.length > 1 ? dtsValues : ptsValues;
+  const steps: number[] = [];
+
+  for (let index: number = 1; index < orderingValues.length; index++) {
+    const step: number = orderingValues[index] - orderingValues[index - 1];
+
+    if (step > 0) steps.push(step);
+  }
+
+  const packetStep: number | null = median(steps);
+  const starts: number[] = [];
+  const ends: number[] = [];
+
+  for (const packet of packets) {
+    const start: number | null = packet.pts ?? packet.dts;
+
+    if (start === null) continue;
+
+    starts.push(start);
+    ends.push(start + (packet.duration ?? packetStep ?? 0));
+  }
+
+  return {
+    firstPts: ptsValues[0] ?? null,
+    lastPts: ptsValues.at(-1) ?? null,
+    firstDts: dtsValues[0] ?? null,
+    lastDts: dtsValues.at(-1) ?? null,
+    lastDuration: packets.at(-1)?.duration ?? packetStep,
+    packetStep,
+    startTime: starts.length > 0 ? Math.min(...starts) : null,
+    endTime: ends.length > 0 ? Math.max(...ends) : null,
+    firstPacketIsKey: packets[0].key,
+    codecSignature,
+    codecExtraData
+  };
+}
+
+/** 在当前Worker内解析一个MPEG-TS分片，避免为每个分片启动ffprobe进程。 */
+export function inspectTsSegment(data: Buffer): SegmentProbeResult {
+  const packetOffset: number = findPacketOffset(data);
+  const streams: StreamDefinition[] = discoverStreams(data, packetOffset);
+  const videoStream: StreamDefinition | undefined = streams.find(
+    (stream: StreamDefinition): boolean => stream.kind === 'video'
+  );
+  const audioStream: StreamDefinition | undefined = streams.find(
+    (stream: StreamDefinition): boolean => stream.kind === 'audio'
+  );
+  const pesPackets: Map<number, PesPacket[]> = collectPesPackets(data, packetOffset, streams);
+  const videoInspection: { packets: MediaPacket[]; codecExtraData: string } | null = videoStream
+    ? inspectVideoPes(pesPackets.get(videoStream.pid) ?? [], videoStream.codec as 'h264' | 'hevc')
+    : null;
+  const audioInspection: AudioInspection | null = audioStream
+    ? inspectAudioPes(pesPackets.get(audioStream.pid) ?? [])
+    : null;
+  const videoPesPackets: PesPacket[] = videoStream ? pesPackets.get(videoStream.pid) ?? [] : [];
+  const audioPesPackets: PesPacket[] = audioStream ? pesPackets.get(audioStream.pid) ?? [] : [];
+
+  if (videoPesPackets.length > 0 && videoInspection?.packets.length === 0) {
+    throw new Error('无法在进程内解析视频PES时间线。');
+  }
+
+  if (audioPesPackets.length > 0 && audioInspection?.packets.length === 0) {
+    throw new Error('无法在进程内解析AAC音频帧。');
+  }
+
+  const timeline: SegmentTimeline = {
+    video: videoInspection && videoStream
+      ? createTimeline(videoInspection.packets, videoStream.codec, videoInspection.codecExtraData)
+      : null,
+    audio: audioInspection
+      ? createTimeline(
+        audioInspection.packets,
+        audioInspection.codecSignature,
+        audioInspection.codecExtraData
+      )
+      : null
+  };
+
+  if (!timeline.video && !timeline.audio) {
+    throw new Error('TS分片中没有可识别的音视频时间线。');
+  }
+
+  return {
+    timeline,
+    audioFormat: timeline.audio ? audioInspection?.format ?? null : null
+  };
+}

--- a/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/timeline.spec.ts
+++ b/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/timeline.spec.ts
@@ -1,0 +1,106 @@
+import {
+  groupSegments,
+  isSourceBoundary,
+  parseMediaPlaylist,
+  type HlsSegment,
+  type SegmentTimeline,
+  type StreamTimeline
+} from './timeline';
+
+function stream(
+  first: number,
+  last: number,
+  duration: number,
+  firstPacketIsKey: boolean = false
+): StreamTimeline {
+  return {
+    firstPts: first,
+    lastPts: last,
+    firstDts: first,
+    lastDts: last,
+    lastDuration: duration,
+    packetStep: duration,
+    startTime: first,
+    endTime: last + duration,
+    firstPacketIsKey,
+    codecSignature: 'same-codec',
+    codecExtraData: 'same-extra-data'
+  };
+}
+
+const segment: HlsSegment = {
+  uri: 'https://example.test/segment.ts',
+  duration: 5,
+  discontinuity: false,
+  localFilename: '_segment_000000.ts'
+};
+
+describe('Pocket48 m3u8 timeline', function(): void {
+  test('parses durations, discontinuities and unique local filenames', function(): void {
+    const result: HlsSegment[] = parseMediaPlaylist([
+      '#EXTM3U',
+      '#EXTINF:5.3,',
+      'https://example.test/repeated.ts?part=1',
+      '#EXT-X-DISCONTINUITY',
+      '#EXTINF:5.852,',
+      'https://example.test/repeated.ts?part=2'
+    ].join('\n'));
+
+    expect(result).toEqual([
+      {
+        uri: 'https://example.test/repeated.ts?part=1',
+        duration: 5.3,
+        discontinuity: false,
+        localFilename: '_segment_000000.ts'
+      },
+      {
+        uri: 'https://example.test/repeated.ts?part=2',
+        duration: 5.852,
+        discontinuity: true,
+        localFilename: '_segment_000001.ts'
+      }
+    ]);
+  });
+
+  test('detects the measured app-switch boundary without a fixed player time', function(): void {
+    const before: SegmentTimeline = {
+      video: stream(0, 5, 0.05, true),
+      audio: stream(0.001811, 5.203089, 0.023211, true)
+    };
+    const after: SegmentTimeline = {
+      video: stream(5.3, 11.102, 0.05, true),
+      audio: stream(5.2263, 11.100956, 0.023211, true)
+    };
+
+    expect(isSourceBoundary(segment, before, after)).toBe(true);
+  });
+
+  test('does not split a continuous media boundary', function(): void {
+    const before: SegmentTimeline = {
+      video: stream(0, 4.95, 0.05, true),
+      audio: stream(0, 4.976789, 0.023211, true)
+    };
+    const after: SegmentTimeline = {
+      video: stream(5, 9.95, 0.05, true),
+      audio: stream(5, 9.976789, 0.023211, true)
+    };
+
+    expect(isSourceBoundary(segment, before, after)).toBe(false);
+  });
+
+  test('groups only at the dynamically detected source boundary', function(): void {
+    const segments: HlsSegment[] = [
+      segment,
+      { ...segment, localFilename: '_segment_000001.ts' },
+      { ...segment, localFilename: '_segment_000002.ts' }
+    ];
+    const timelines: SegmentTimeline[] = [
+      { video: stream(0, 4.95, 0.05, true), audio: stream(0, 4.976789, 0.023211, true) },
+      { video: stream(5, 9.95, 0.05, true), audio: stream(5, 9.976789, 0.023211, true) },
+      { video: stream(10.25, 14.95, 0.05, true), audio: stream(10, 14.976789, 0.023211, true) }
+    ];
+    const groups: HlsSegment[][] = groupSegments(segments, timelines);
+
+    expect(groups.map((group: HlsSegment[]): number => group.length)).toEqual([2, 1]);
+  });
+});

--- a/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/timeline.ts
+++ b/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48M3u8Download.worker/timeline.ts
@@ -1,0 +1,203 @@
+export type HlsSegment = {
+  uri: string;
+  duration: number;
+  discontinuity: boolean;
+  localFilename: string;
+};
+
+export type StreamTimeline = {
+  firstPts: number | null;
+  lastPts: number | null;
+  firstDts: number | null;
+  lastDts: number | null;
+  lastDuration: number | null;
+  packetStep: number | null;
+  startTime: number | null;
+  endTime: number | null;
+  firstPacketIsKey: boolean;
+  codecSignature: string;
+  codecExtraData: string;
+};
+
+export type SegmentTimeline = {
+  video: StreamTimeline | null;
+  audio: StreamTimeline | null;
+};
+
+const TIMELINE_TOLERANCE: number = 0.12;
+
+/** 解析口袋48媒体m3u8，并为每个远端分片分配不会重名的本地文件名。 */
+export function parseMediaPlaylist(data: string): HlsSegment[] {
+  const result: HlsSegment[] = [];
+  let duration: number | null = null;
+  let discontinuity: boolean = false;
+
+  for (const rawLine of data.split(/\r?\n/)) {
+    const line: string = rawLine.trim();
+
+    if (line.startsWith('#EXTINF:')) {
+      const value: number = Number.parseFloat(line.slice('#EXTINF:'.length).split(',')[0]);
+
+      duration = Number.isFinite(value) ? value : 0;
+    } else if (line === '#EXT-X-DISCONTINUITY') {
+      discontinuity = true;
+    } else if (/^https?:\/\//i.test(line)) {
+      result.push({
+        uri: line,
+        duration: duration ?? 0,
+        discontinuity,
+        localFilename: `_segment_${ String(result.length).padStart(6, '0') }.ts`
+      });
+      duration = null;
+      discontinuity = false;
+    }
+  }
+
+  return result;
+}
+
+function getBoundaryStart(stream: StreamTimeline): number | null {
+  return stream.firstDts ?? stream.firstPts;
+}
+
+function getBoundaryEnd(stream: StreamTimeline): number | null {
+  const lastTimestamp: number | null = stream.lastDts ?? stream.lastPts;
+
+  if (lastTimestamp === null) return null;
+
+  return lastTimestamp + (stream.lastDuration ?? stream.packetStep ?? 0);
+}
+
+function getGap(previous: StreamTimeline | null, current: StreamTimeline | null): number | null {
+  if (!previous || !current) return null;
+
+  const end: number | null = getBoundaryEnd(previous);
+  const start: number | null = getBoundaryStart(current);
+
+  return end === null || start === null ? null : start - end;
+}
+
+function changedCodec(previous: StreamTimeline | null, current: StreamTimeline | null): boolean {
+  if (Boolean(previous) !== Boolean(current)) return true;
+  if (!previous || !current) return false;
+  if (previous.codecSignature !== current.codecSignature) return true;
+
+  return Boolean(
+    previous.codecExtraData
+    && current.codecExtraData
+    && previous.codecExtraData !== current.codecExtraData
+  );
+}
+
+/**
+ * 根据相邻分片的实际媒体数据判断来源是否发生切换。
+ *
+ * 切换app的典型特征是视频时间线出现异常缺口、音频仍然连续，且后一段
+ * 从关键帧开始。这里只建立分组边界，不调整任何一路的时间戳。
+ */
+export function isSourceBoundary(
+  currentSegment: HlsSegment,
+  previous: SegmentTimeline,
+  current: SegmentTimeline
+): boolean {
+  if (currentSegment.discontinuity) return true;
+
+  if (changedCodec(previous.video, current.video) || changedCodec(previous.audio, current.audio)) {
+    return true;
+  }
+
+  const videoGap: number | null = getGap(previous.video, current.video);
+  const audioGap: number | null = getGap(previous.audio, current.audio);
+
+  if (videoGap !== null && audioGap !== null) {
+    const videoChanged: boolean = Math.abs(videoGap) > TIMELINE_TOLERANCE;
+    const audioChanged: boolean = Math.abs(audioGap) > TIMELINE_TOLERANCE;
+    const trackGapChanged: boolean = Math.abs(videoGap - audioGap) > TIMELINE_TOLERANCE;
+    const startsWithKeyFrame: boolean = current.video?.firstPacketIsKey ?? false;
+
+    if (startsWithKeyFrame && trackGapChanged && (videoChanged || audioChanged)) {
+      return true;
+    }
+
+    return videoChanged && audioChanged;
+  }
+
+  const availableGap: number | null = videoGap ?? audioGap;
+
+  return availableGap !== null && Math.abs(availableGap) > TIMELINE_TOLERANCE;
+}
+
+/** 将HLS分片按检测出的来源边界划分为连续来源组。 */
+export function groupSegments(segments: HlsSegment[], timelines: SegmentTimeline[]): HlsSegment[][] {
+  if (segments.length !== timelines.length) {
+    throw new Error('HLS分片数量与媒体探测结果不一致。');
+  }
+
+  if (segments.length === 0) return [];
+
+  const groups: HlsSegment[][] = [[segments[0]]];
+
+  for (let index: number = 1; index < segments.length; index++) {
+    if (isSourceBoundary(segments[index], timelines[index - 1], timelines[index])) {
+      groups.push([]);
+    }
+
+    groups[groups.length - 1].push(segments[index]);
+  }
+
+  return groups;
+}
+
+/** 为一个连续来源组创建只引用本地分片的HLS清单。 */
+export function createGroupPlaylist(segments: HlsSegment[]): string {
+  const targetDuration: number = Math.max(
+    1,
+    ...segments.map((segment: HlsSegment): number => Math.ceil(segment.duration))
+  );
+  const lines: string[] = [
+    '#EXTM3U',
+    '#EXT-X-VERSION:3',
+    `#EXT-X-TARGETDURATION:${ targetDuration }`,
+    '#EXT-X-MEDIA-SEQUENCE:0',
+    '#EXT-X-PLAYLIST-TYPE:VOD'
+  ];
+
+  for (const segment of segments) {
+    lines.push(`#EXTINF:${ segment.duration.toFixed(6) },`);
+    lines.push(segment.localFilename);
+  }
+
+  lines.push('#EXT-X-ENDLIST');
+
+  return `${ lines.join('\n') }\n`;
+}
+
+/** 根据重封装后文件的实际包时间戳计算媒体时长。 */
+export function getTimelineDuration(timeline: SegmentTimeline): number {
+  const streams: StreamTimeline[] = [timeline.video, timeline.audio]
+    .filter((stream: StreamTimeline | null): stream is StreamTimeline => stream !== null);
+  const starts: number[] = streams
+    .map((stream: StreamTimeline): number | null => stream.startTime)
+    .filter((value: number | null): value is number => value !== null);
+  const ends: number[] = streams
+    .map((stream: StreamTimeline): number | null => stream.endTime)
+    .filter((value: number | null): value is number => value !== null);
+
+  if (starts.length === 0 || ends.length === 0) {
+    throw new Error('无法从重封装文件中计算媒体时长。');
+  }
+
+  return Math.max(...ends) - Math.min(...starts);
+}
+
+/** 创建仅引用完整来源组文件的FFmpeg concat清单。 */
+export function createGroupConcatFile(groupFiles: Array<{ filename: string; duration: number }>): string {
+  const lines: string[] = ['ffconcat version 1.0'];
+
+  for (const groupFile of groupFiles) {
+    lines.push(`file '${ groupFile.filename.replaceAll("'", "'\\''") }'`);
+    lines.push(`duration ${ groupFile.duration.toFixed(6) }`);
+  }
+
+  return `${ lines.join('\n') }\n`;
+}

--- a/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48Record.tsx
+++ b/packages/48tools/src/pages/48/Pocket48/Pocket48Record/Pocket48Record.tsx
@@ -303,7 +303,9 @@ function Pocket48Record(props: {}): ReactElement {
       }
 
       let requestIdleID: number | null = null;
-      const worker: Worker = (isM3u8 && downloadType === 1 ? getRecordVideoDownloadWorker : getFFmpegDownloadWorker)();
+      const worker: Worker = isM3u8 && downloadType === 0
+        ? new Worker(new URL('./Pocket48M3u8Download.worker/Pocket48M3u8Download.worker.ts', import.meta.url))
+        : (isM3u8 && downloadType === 1 ? getRecordVideoDownloadWorker : getFFmpegDownloadWorker)();
 
       worker.addEventListener('message', function(workerEvent: MessageEvent<MessageEventData>) {
         const { type }: MessageEventData = workerEvent.data;


### PR DESCRIPTION
## 问题背景

口袋48主播在直播过程中切换应用时，部分 HLS 分片会出现以下情况：

- 音视频 PTS/DTS 时间线发生不连续
- 编码参数或媒体轨道组成发生变化
- 部分分片只有视频流，没有音频流
- m3u8 不一定提供对应的 `#EXT-X-DISCONTINUITY` 标记

原下载逻辑会继续将切换前后的 TS 分片追加到同一个文件中，导致媒体时间线不连续，最终文件出现音画不同步的问题。

将不同媒体来源分别保存、标准化后再合并，可以恢复播放器中的音画同步；但如果各来源的音频流结构不一致，例如部分分段没有音频，剪映等编辑软件仍可能无法识别切换点后的音频频谱。因此，合并前还需要为无音频分段补充匹配格式的静音轨，确保所有分段具有一致、连续的音视频流结构。

## 处理方式

在媒体来源变化后分段保存，同时保持最终输出为一个完整视频：

1. 按顺序下载每个 TS 分片。
2. 连续分片继续追加到当前 TS 文件，保留下载中断后已经完成的内容。
3. 根据 PTS/DTS 连续性、关键帧、编码参数和 M3U8 中的 `#EXT-X-DISCONTINUITY` 标记动态识别来源边界。
4. 检测到来源变化后开始写入新的 TS 分段。
5. 首段沿用原文件名，后续分段使用 `_002`、`_003` 等后缀。
6. 如果最终只有一个分段，则直接保留该文件，不执行额外处理。
7. 如果产生多个分段，则分别标准化时间戳，再合并为最终的单个 TS 文件。
8. 如果部分分段没有音频，则在合并前补充与现有音频格式匹配的静音轨，保证所有分段具有一致的音视频流结构。

## FFmpeg 配置与 FFprobe 依赖

项目现有新人引导只要求用户下载 FFmpeg，并配置“FFmpeg 可执行文件的路径”。FFmpeg 配置界面也只保存一个 `FFMPEG_PATH`；未配置有效路径时，程序使用 PATH 中的 `ffmpeg`。

本次处理没有增加新的用户配置项，而是根据现有 FFmpeg 配置定位 `ffprobe`：

- 用户配置具体的 FFmpeg 可执行文件时，使用同目录下的 `ffprobe` 或 `ffprobe.exe`。
- 程序使用 PATH 中的 `ffmpeg` 时，相应使用 PATH 中的 `ffprobe`。

这意味着，使用包含配套 `ffprobe` 的 FFmpeg 工具目录或 PATH 环境时，无需增加额外配置；如果用户只配置了独立 FFmpeg 二进制、包装脚本或自定义名称的可执行文件，则解析回退或多段合并可能无法找到 `ffprobe`。这是本次实现相对于现有 FFmpeg 配置契约新增的运行环境边界。

## 性能表现

常规分片的时间线和编码信息由 Worker 直接解析，分片探测阶段不需要逐片启动 ffprobe 子进程。

ffprobe 仅用于以下情况：

- 进程内解析无法识别的特殊分片
- 多来源合并时获取重封装分段的必要时长

最终合并阶段的调用次数与来源分段数量相关，而不是与直播的 TS 分片总数相关。

## 影响范围

- 仅调整口袋48普通 M3U8 录播下载流程
- 单一来源录播保持直接逐片追加的处理方式
- 多来源录播最终仍输出一个 TS 文件
- 不包含固定的切换时间或针对特定测试视频的判断
- 进程内解析失败时保留 ffprobe 兼容路径
